### PR TITLE
Add flushall endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ or
 
 Flushes the APIBANLOCAL/APIBANLOCALv6 chain.
 
-* **URL**: /[flush|flushset]
+* **URL**: /[flush|flushall|flushset]
 * **METHOD**: `GET`
 * **Auth**: None
 * **RESPONSE**: 200/4xx/5xx

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func main() {
 	router.HandleFunc("GET /block/{ipaddress}", addIPAddress)
 	router.HandleFunc("GET /blockip/{ipaddress}", addIPAddress)
 	router.HandleFunc("GET /flush", flushSet)
+	router.HandleFunc("GET /flushall", flushSet)
 	router.HandleFunc("GET /flushset", flushSet)
 	router.HandleFunc("GET /remove/{ipaddress}", removeIPAddress)
 	router.HandleFunc("GET /removeip/{ipaddress}", removeIPAddress)


### PR DESCRIPTION
Added `flushall` to mimic the legacy iptables client.

* Updated main.go to add the endpoint
* Updated README.md to update the docs